### PR TITLE
Add Shell version 3.18.5 to compatibility list

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "uuid": "vpn-indicator@howdoicomputer.fastmail.com",
-    "shell-version": ["3.22.1"],
+    "shell-version": ["3.22.1","3.18.5"],
     "name": "VPN Indicator",
     "description": "A status indicator for a VPN connection."
 }


### PR DESCRIPTION
Tested and found to work with 3.18.5 which is the shell version for the current Ubuntu LTS (16.04).