### PR TITLE
Also check for ProtonVPN's proton0 device

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![alt tag](demo.png)
 
-This is a *really* simple extension that basically polls for a tun0 device from ifconfig on a three second timer. Simple purpose aside, it was actually incredibly difficult to make due to a lack of documentation on Gnome Shell extensions.
+This is a *really* simple extension that basically polls for a VPN device from ifconfig on a three second timer. Simple purpose aside, it was actually incredibly difficult to make due to a lack of documentation on Gnome Shell extensions.
 
 I would like to note down these pieces of documentation for anyone stumbling across this repo:
 

--- a/extension.js
+++ b/extension.js
@@ -23,7 +23,7 @@ const VpnIndicator = new Lang.Class({
     },
 
     _checkVPN: function() {
-        let [res, out, err, exit] = GLib.spawn_sync(null, ["/bin/bash", "-c", "ifconfig -a | grep tun0"], null, GLib.SpawnFlags.SEARCH_PATH, null);
+        let [res, out, err, exit] = GLib.spawn_sync(null, ["/bin/bash", "-c", "ifconfig -a | grep -E '^(tun0|proton0)'"], null, GLib.SpawnFlags.SEARCH_PATH, null);
 
         return exit;
     },


### PR DESCRIPTION
I use [ProtonVPN](https://protonvpn.com/support/linux-vpn-setup/). On my computer, the VPN device is listed as `proton0`, not `tun0` so I propose this simple tweak for the device detection.